### PR TITLE
feat: animate: allow following while stopping at inputs EOF

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ opts
   -y [width]:[prec]:[side] - set y label format
   -c <color> - set color of next data source
   -f - "follow" input
+  -A - "animate" input by following and exit
   -S <milliseconds> - follow rate
   -m - visually merge overlapping lines, e.g. ╯ and ╰ form ┴
   -s %<charset>|ascii|unicode - set output charset

--- a/docs/plot.1.scd.in
+++ b/docs/plot.1.scd.in
@@ -27,6 +27,10 @@ plot reads sequences of numbers and outputs a line graph.
 	the length of the plot reaches the maximum width, begin scrolling to
 	the left.
 
+*-A*
+	"animate" input by following and exit. The behaviour is identical
+	to the "follow" -f feature, but upon input EOF, the plot stops.
+
 *-b* [min]:[max]
 	set fixed plot bounds (instead of dynamically evaluating bounds).
 

--- a/src/follow.c
+++ b/src/follow.c
@@ -72,5 +72,5 @@ follow_plot(struct plot *p, long ms)
 		nanosleep(&sleep, NULL);
 	}
 
-	printf("\033[%dB\033[?12l\033[?25h\n", height);
+	printf("\033[%dB\033[?12l\033[?25h", height);
 }

--- a/src/follow.c
+++ b/src/follow.c
@@ -30,6 +30,7 @@ install_signal_handler(void)
 void
 follow_plot(struct plot *p, long ms)
 {
+	int eof;
 	size_t i;
 	int height = p->height;
 
@@ -48,10 +49,18 @@ follow_plot(struct plot *p, long ms)
 
 	while (loop) {
 		if (!pdtry_all_buffers(p, 1)) {
+			eof = 1;
 			for (i = 0; i < p->datasets; i++) {
 				if (feof(p->data[i].src.src)) {
 					clearerr(p->data[i].src.src);
 				}
+				else {
+					eof = 0;
+				}
+			}
+
+			if (p->animate && eof) {
+				loop = 0;
 			}
 		}
 

--- a/src/input.c
+++ b/src/input.c
@@ -138,7 +138,7 @@ pdtry_all_buffers(struct plot *p, int shift)
 	}
 
 	for (i = 0; i < p->datasets; i++) {
-		if (shift && p->data[i].len - min_len > MAX_AHEAD) {
+		if (!p->animate && shift && p->data[i].len - min_len > MAX_AHEAD) {
 			continue;
 		}
 

--- a/src/main.c
+++ b/src/main.c
@@ -17,7 +17,7 @@ main(int argc, char **argv)
 		plot_add(&p, stdin, lc);
 	}
 
-	if (p.follow) {
+	if (p.animate || p.follow) {
 		set_input_buffer_size(8);
 		follow_plot(&p, p.follow_rate);
 	} else {

--- a/src/opts.c
+++ b/src/opts.c
@@ -24,6 +24,7 @@ print_usage(FILE *f)
 		"  -y [width]:[prec]:[side] - set y label format\n"
 		"  -c <color> - set color of next data source\n"
 		"  -f - \"follow\" input\n"
+		"  -A - \"animate\" input by following and exit\n"
 		"  -S <milliseconds> - follow rate\n"
 		"  -m - visually merge overlapping lines, e.g. ╯ and ╰ form ┴\n"
 		"  -s %%<charset>|ascii|unicode - set output charset\n"
@@ -209,13 +210,16 @@ parse_opts(struct plot *p, int argc, char **argv)
 	char opt;
 	int lc = 0;
 
-	while ((opt = getopt(argc, argv, "a:b:c:d:fhi:ms:S:x:y:")) != -1) {
+	while ((opt = getopt(argc, argv, "a:Ab:c:d:fhi:ms:S:x:y:")) != -1) {
 		switch (opt) {
 		case 'a':
 			if ((p->average = strtol(optarg, NULL, 10)) < 0) {
 				fprintf(stderr, "invalid average arg\n");
 				exit(EXIT_FAILURE);
 			}
+			break;
+		case 'A':
+			p->animate = 1;
 			break;
 		case 'b':
 			set_fixed_plot_bounds(optarg, p);

--- a/src/opts.c
+++ b/src/opts.c
@@ -175,7 +175,7 @@ add_data_from_file(char *filename, struct plot *p, int color)
 	FILE *f = (strcmp(filename, "-") == 0) ? stdin : fopen(optarg, "r");
 
 	if (f == NULL) {
-		fprintf(stderr, "no such file\n");
+		fprintf(stderr, "no such file: %s\n", filename);
 		exit(EXIT_FAILURE);
 	}
 

--- a/src/plot.c
+++ b/src/plot.c
@@ -25,7 +25,10 @@ plot_init(struct plot *plot)
 	plot->height = 24;
 	plot->width = 80;
 
+	plot->animate = 0;
+	plot->follow = 0;
 	plot->follow_rate = 100;
+
 	plot->average = 1;
 
 	plot->datasets = 0;

--- a/src/plot.h
+++ b/src/plot.h
@@ -113,6 +113,7 @@ struct plot {
 	unsigned int width;
 	long follow_rate;
 	long average;
+	int animate;
 	int follow;
 	int color;
 	int merge_plot_peices;

--- a/src/util.c
+++ b/src/util.c
@@ -38,7 +38,7 @@ char_to_color(char c)
 	case 'C': n = 96; break;
 	case 'W': n = 97; break;
 	default:
-		fprintf(stderr, "inavlid color char: %c\n", c);
+		fprintf(stderr, "invalid color char: %c\n", c);
 		n = 0;
 		break;
 	}


### PR DESCRIPTION
 * Test:
    - seq 1 100 | shuf >./tests/tmp.1.raw
    - seq 1 150 | shuf >./tests/tmp.2.raw
    - seq 1 200 | shuf >./tests/tmp.3.raw
    - ./build/plot -c C -A -i ./tests/tmp.1.raw -c R \
        -i ./tests/tmp.2.raw -c G -i ./tests/tmp.3.raw \
        -S 200 -x 5: -y 10:3:1
    - rm -f ./tests/tmp.1.raw ./tests/tmp.2.raw ./tests/tmp.3.raw