### PR TITLE
Input cleanup

### DIFF
--- a/src/follow.c
+++ b/src/follow.c
@@ -47,7 +47,7 @@ follow_plot(struct plot *p, long ms)
 	printf("\033[?25l");
 
 	while (loop) {
-		if (!pdtry_all_buffers(p, 1)) {
+		if (!pdtry_all_buffers(p)) {
 			eof = 1;
 			for (i = 0; i < p->datasets; i++) {
 				if (feof(p->data[i].src.src)) {

--- a/src/input.c
+++ b/src/input.c
@@ -170,10 +170,24 @@ pdtry_all_buffers(struct plot *p, int shift)
 	return read;
 }
 
-void
-pdread_all_available(struct plot *p)
+int
+pdread_no_shift(struct plot *p)
 {
-	while (pdtry_all_buffers(p, 0)) {
-		/* nothing */
+	size_t i;
+	uint32_t read = 0,
+		 shifts[MAX_DATA] = { 0 };
+
+	for (i = 0; i < p->datasets; i++) {
+		read |= pdtry_buffer(&p->data[i], p->width, &shifts[i], 0, p->average);
 	}
+	return read;
+}
+
+ void
+ pdread_all_available(struct plot *p)
+ {
+	uint32_t read = 0;
+	do{
+		read = pdread_no_shift(p);
+	}while(read);
 }

--- a/src/input.c
+++ b/src/input.c
@@ -41,7 +41,7 @@ read_numbers(struct input *in, double *dest, size_t max)
 
 		lr = i;
 		dest[len] = strtod(&in->buf[i], &endptr);
-		(len)++;
+		len++;
 
 		if (len == max) {
 			break;
@@ -87,27 +87,23 @@ pd_avg(struct plot_data *pd, double *read_arr, double *arr, size_t *read_len, ui
 static int
 pdtry_buffer_noshift(struct plot_data *pd, size_t max_w, uint32_t avg_by)
 {
-	size_t read_len, len = 0;
+	size_t len = 0;
 	double read_arr[TMP_ARR_SIZE];
 	double arr[TMP_ARR_SIZE];
 
 	if (pd->len >= max_w) {
 		return 0;
-	} else if ((read_len = read_numbers(&pd->src, read_arr, TMP_ARR_SIZE)) == 0) {
+	} else if ((len = read_numbers(&pd->src, read_arr, TMP_ARR_SIZE)) == 0) {
 		return 0;
 	}
 
-	pd_avg(pd, read_arr, arr, &read_len, avg_by);
-	len = read_len;
+	pd_avg(pd, read_arr, arr, &len, avg_by);
 
 	if (len >= max_w) {
 		memcpy(pd->data, arr, max_w * sizeof(double));
-
 		pd->len = max_w;
 		return 1;
-	}
-
-	if (len + pd->len > max_w) {
+	} else if(len + pd->len > max_w) {
 		len = max_w - pd->len;
 	}
 
@@ -115,28 +111,25 @@ pdtry_buffer_noshift(struct plot_data *pd, size_t max_w, uint32_t avg_by)
 	pd->len += len;
 	return 1;
 }
+
 static int
 pdtry_buffer_shift(struct plot_data *pd, size_t max_w, uint32_t *shifted, uint32_t avg_by)
 {
-	size_t read_len, len = 0;
+	size_t len = 0;
 	double read_arr[TMP_ARR_SIZE];
 	double arr[TMP_ARR_SIZE];
 
-	if ((read_len = read_numbers(&pd->src, read_arr, TMP_ARR_SIZE)) == 0) {
+	if ((len = read_numbers(&pd->src, read_arr, TMP_ARR_SIZE)) == 0) {
 		return 0;
 	}
 
-	pd_avg(pd, read_arr, arr, &read_len, avg_by);
-	len = read_len;
+	pd_avg(pd, read_arr, arr, &len, avg_by);
 
 	if (len >= max_w) {
 		memcpy(pd->data, &arr[len - max_w], max_w * sizeof(double));
-
 		pd->len = max_w;
 		return 1;
-	}
-
-	if (len + pd->len > max_w) {
+	} else if (len + pd->len > max_w) {
 		*shifted = max_w - pd->len + len;
 		if (pd->len < *shifted) {
 			pd->len = 0;
@@ -205,5 +198,5 @@ pdtry_all_buffers(struct plot *p)
 		for (i = 0, read = 0; i < p->datasets; i++) {
 			read |= pdtry_buffer_noshift(&p->data[i], p->width, p->average);
 		}
-	}while(read);
+	} while(read);
 }

--- a/src/input.c
+++ b/src/input.c
@@ -66,7 +66,7 @@ shift_arr(double *arr, size_t off, size_t amnt)
 }
 
 static int
-pdtry_buffer(struct plot_data *pd, size_t max_w, long *shifted, size_t shift, uint32_t avg_by)
+pdtry_buffer(struct plot_data *pd, size_t max_w, uint32_t *shifted, size_t shift, uint32_t avg_by)
 {
 	size_t read_len, len = 0, i;
 	double read_arr[TMP_ARR_SIZE];
@@ -131,7 +131,6 @@ pdtry_all_buffers(struct plot *p, int shift)
 		 shifts[MAX_DATA] = { 0 },
 		 maxshift = 0,
 		 min_len = p->width;
-	long shifted = 0;
 
 	if (shift) {
 		for (i = 0; i < p->datasets; i++) {
@@ -146,14 +145,10 @@ pdtry_all_buffers(struct plot *p, int shift)
 			continue;
 		}
 
-		read |= pdtry_buffer(&p->data[i], p->width, &shifted, shift, p->average);
+		read |= pdtry_buffer(&p->data[i], p->width, &shifts[i], shift, p->average);
 
-		if (shift && shifted) {
-			shifts[i] = shifted;
-			if (shifted > maxshift) {
-				maxshift = shifted;
-			}
-			shifted = 0;
+		if (shifts[i] > maxshift) {
+			maxshift = shifts[i];
 		}
 	}
 

--- a/src/input.h
+++ b/src/input.h
@@ -6,6 +6,6 @@
 #include "plot.h"
 
 void pdread_all_available(struct plot *p);
-int pdtry_all_buffers(struct plot *p, int shift);
+int pdtry_all_buffers(struct plot *p);
 void set_input_buffer_size(size_t new_size);
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -17,7 +17,7 @@ main(int argc, char **argv)
 		plot_add(&p, stdin, lc);
 	}
 
-	if (p.flags & plot_flag_animate || p.flags & plot_flag_follow) {
+	if (p.flags & (plot_flag_animate|plot_flag_follow)) {
 		set_input_buffer_size(8);
 		follow_plot(&p, p.follow_rate);
 	} else {


### PR DESCRIPTION
This is an initial PR towards improving the input system to help with flexibility and to allow for future features (per discussion in #13)

currently `pdtry_all_buffers()` and `pdtry_buffer()` use an argument (`shift`) to branch logic depending on whether `plot` is called with `-f/-A`

within those functions, however, there is relatively little shared code

At a high level this PR reduces the amount of branching (which improves readability and flexibility in my opinion) required by separating the code that doesn't require shifting into separate functions.   

The git diff doesn't look great, so here's an explanation:

in `pdtry_all_buffers()`, most of the function was only used by the `shift=1` codepath, basically this just moves the `shift=0` code path out into `pdread_all_available()`
```
pdtry_all_buffers(p, 1)    ->   pdtry_all_buffers(p)
pdtry_all_buffers(p, 0)    ->   pdread_all_available(p)
```

most of code path that was shared by `shift=1` and `shift=0` in `pdtry_buffer()` was previously the code used for calculating the average, this now has its own function:
```
pd_avg()
```

and since the remainder of the code in `pdtry_buffer()` was nested branching based on the `shift` value, this code was separated into its own `*_shift()`/`*_noshift()` functions
```
pdtry_buffer(.., 0, ..)   -> pdtry_buffer_noshift()
pdtry_buffer(.., 1, ..)   -> pdtry_buffer_shift()
```