### PR TITLE
fix: support meson 0.44.1 by using the 'configuration_data' class 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,23 +8,23 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2.0.0
-    - name: Dependencies
-      run: |
-        sudo apt update
-        sudo apt install -y gcc meson valgrind
-    - name: Prebuild
-      run: |
-        rm -rf build
-        meson setup \
-          --buildtype=release \
-          -Dbuild_docs=disabled \
-          -Dtest=true \
-          build
-    - name: Build
-      run: |
-        ninja -C build
-    - name: Test
-      run: |
-        ninja -C build test
+      - name: Checkout
+        uses: actions/checkout@v2.0.0
+      - name: Dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y gcc git meson valgrind
+      - name: Prebuild
+        run: |
+          rm -rf build
+          meson setup \
+            --buildtype=release \
+            -Dbuild_docs=disabled \
+            -Dtest=true \
+            build
+      - name: Build
+        run: |
+          ninja -C build
+      - name: Test
+        run: |
+          ninja -C build test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,7 +7,7 @@ build:
   image: alpine:edge
   script:
     # Install dependencies
-    - apk add g++ meson ninja python3 scdoc valgrind
+    - apk add g++ git meson ninja python3 scdoc valgrind
     # Prepare packages
     - rm -rf ./build
     - meson setup --buildtype=release -Dbuild_docs=enabled -Dtest=true ./build

--- a/meson.build
+++ b/meson.build
@@ -39,10 +39,9 @@ else
 	git_sha = 'unknown'
 endif
 
-version_info = {
-	'version': meson.project_version(),
-	'vcs_tag': git_sha,
-}
+version_info = configuration_data()
+version_info.set('version', meson.project_version())
+version_info.set('vcs_tag', git_sha)
 
 deps = [
 	cc.find_library('m', required : true),

--- a/packaging/plot.spec
+++ b/packaging/plot.spec
@@ -7,7 +7,7 @@ URL: https://github.com/annacrombie/plot
 Prefix: /usr
 Source0: %{expand:%%(pwd)}
 BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}%{dist}-XXXXXX)
-BuildRequires: gcc, meson, ninja-build, rpm-build
+BuildRequires: gcc, git, meson, ninja-build, rpm-build
 
 %description
 Generate a simple ascii plot.

--- a/src/opts.c
+++ b/src/opts.c
@@ -14,7 +14,7 @@ static void
 print_usage(FILE *f)
 {
 	fprintf(f,
-		"plot v%s-%s\n"
+		"plot %s-%s\n"
 		"usage: plot [opts]\n"
 		"opts\n"
 		"  -i <filename>|- - specify a data source\n"


### PR DESCRIPTION
* Builds broken on CentOS 6 (32 / 64), fixed `configuration_data` syntax on meson 0.44.1
* Added git installations
* Restored the original versions style